### PR TITLE
Fix team member budget display formatting

### DIFF
--- a/ui/litellm-dashboard/src/components/team/TeamMemberTab.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamMemberTab.test.tsx
@@ -248,6 +248,43 @@ describe("TeamMembersComponent", () => {
     expect(screen.getByText(/10000 TPM/)).toBeInTheDocument();
   });
 
+  it("should display large decimal team member budgets with commas", () => {
+    renderWithProviders(
+      <TeamMembersComponent
+        teamData={createMockTeamData({
+          team_memberships: [
+            {
+              user_id: "user1@test.com",
+              team_id: "team-123",
+              budget_id: "budget1",
+              spend: 3272.038800300061,
+              total_spend: 1890.0782522499949,
+              litellm_budget_table: {
+                budget_id: "budget1",
+                soft_budget: null,
+                max_budget: 3270.599860154001,
+                max_parallel_requests: null,
+                tpm_limit: null,
+                rpm_limit: null,
+                model_max_budget: null,
+                budget_duration: null,
+                budget_reset_at: null,
+              },
+            },
+          ],
+        })}
+        canEditTeam={false}
+        handleMemberDelete={mockHandleMemberDelete}
+        setSelectedEditMember={mockSetSelectedEditMember}
+        setIsEditMemberModalVisible={mockSetIsEditMemberModalVisible}
+        setIsAddMemberModalVisible={mockSetIsAddMemberModalVisible}
+      />,
+    );
+
+    expect(screen.getByText("$3,270.5999")).toBeInTheDocument();
+    expect(screen.queryByText("$-")).not.toBeInTheDocument();
+  });
+
   it("should display No Limit for budget when member has no budget", () => {
     renderWithProviders(
       <TeamMembersComponent

--- a/ui/litellm-dashboard/src/components/team/TeamMemberTab.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamMemberTab.tsx
@@ -58,14 +58,14 @@ export default function TeamMemberTab({
     return membership?.total_spend ?? 0;
   };
 
-  const getUserBudget = (userId: string | null): string | null => {
+  const getUserBudget = (userId: string | null): number | null => {
     if (!userId) return null;
     const membership = teamData.team_memberships.find((tm) => tm.user_id === userId);
     const maxBudget = membership?.litellm_budget_table?.max_budget;
     if (maxBudget === null || maxBudget === undefined) {
       return null;
     }
-    return formatNumber(maxBudget);
+    return maxBudget;
   };
 
   // Helper function to get rate limits for a user
@@ -168,7 +168,7 @@ export default function TeamMemberTab({
         const budget = getUserBudget(record.user_id);
         return (
           <Typography.Text>
-            {budget ? `$${formatNumberWithCommas(Number(budget), 4)}` : "No Limit"}
+            {budget !== null ? `$${formatNumberWithCommas(budget, 4)}` : "No Limit"}
           </Typography.Text>
         );
       },


### PR DESCRIPTION
## Summary
- Fix team member budget rendering so numeric budgets are formatted directly instead of converting an already comma-formatted string back to `Number`.
- Add a regression test for large decimal budgets like `$3,270.5999`, which previously rendered as `$-`.

## Test Plan
- `cd ui/litellm-dashboard && npm test -- --run src/components/team/TeamMemberTab.test.tsx`

_This PR was created by an AI agent (OpenHands) on behalf of Graham Neubig._